### PR TITLE
feat: brightness slider, BitGo title fix, footer cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,9 +13,9 @@
   <meta property="og:description" content="Staff Engineer with 11+ years building blockchain infrastructure, platform services, and distributed systems across 4 industries.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://www.doddanna.com">
-  <meta property="og:image" content="https://github.com/Doddanna17.png?size=460">
-  <meta property="og:image:width" content="460">
-  <meta property="og:image:height" content="460">
+  <meta property="og:image" content="https://www.doddanna.com/og-image.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
   <meta property="og:image:alt" content="Doddanna B — Staff Engineer, Platform Architect, Blockchain Infrastructure">
   <meta property="og:locale" content="en_US">
   <meta property="og:site_name" content="Doddanna B">
@@ -24,11 +24,11 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Doddanna B — Staff Engineer · Platform Architect · Blockchain">
   <meta name="twitter:description" content="Staff Engineer with 11+ years building blockchain infrastructure, platform services, and distributed systems across 4 industries.">
-  <meta name="twitter:image" content="https://github.com/Doddanna17.png?size=460">
+  <meta name="twitter:image" content="https://www.doddanna.com/og-image.png">
   <meta name="twitter:image:alt" content="Doddanna B — Staff Engineer, Platform Architect, Blockchain Infrastructure">
 
   <link rel="canonical" href="https://www.doddanna.com">
-  <link rel="icon" type="image/png" href="https://github.com/Doddanna17.png?size=32">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="apple-touch-icon" sizes="180x180" href="https://github.com/Doddanna17.png?size=180">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/index.html
+++ b/index.html
@@ -1397,6 +1397,87 @@
       .theme-toggle { cursor: pointer; }
     }
 
+    /* ── Brightness Slider (light mode only) ── */
+    .brightness-control {
+      position: fixed;
+      top: 72px;
+      right: 20px;
+      z-index: 99996;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 6px 12px;
+      opacity: 0;
+      pointer-events: none;
+      transform: translateY(-8px);
+      transition: opacity 0.35s ease, transform 0.35s var(--ease-out-expo);
+    }
+    [data-theme="light"] .brightness-control {
+      opacity: 1;
+      pointer-events: auto;
+      transform: translateY(0);
+    }
+    .brightness-icon {
+      width: 16px;
+      height: 16px;
+      flex-shrink: 0;
+      color: var(--text-muted);
+    }
+    .brightness-slider {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 80px;
+      height: 4px;
+      border-radius: 2px;
+      background: linear-gradient(to right, #888894, #f6f6f9);
+      outline: none;
+      cursor: pointer;
+    }
+    .brightness-slider::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      background: var(--accent);
+      border: 2px solid var(--bg-card);
+      box-shadow: 0 1px 4px rgba(0,0,0,0.15);
+      cursor: pointer;
+      transition: transform 0.2s var(--ease-spring), box-shadow 0.2s;
+    }
+    .brightness-slider::-webkit-slider-thumb:hover {
+      transform: scale(1.2);
+      box-shadow: 0 2px 8px var(--accent-glow);
+    }
+    .brightness-slider::-moz-range-thumb {
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      background: var(--accent);
+      border: 2px solid var(--bg-card);
+      box-shadow: 0 1px 4px rgba(0,0,0,0.15);
+      cursor: pointer;
+    }
+    .brightness-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 99990;
+      pointer-events: none;
+      background: transparent;
+      transition: background 0.4s ease;
+    }
+    @media (max-width: 640px) {
+      .brightness-control {
+        right: 12px;
+        top: 68px;
+        padding: 5px 10px;
+      }
+      .brightness-slider { width: 60px; }
+    }
+
     /* ══════════════════════════════════════════════════
        REDUCED MOTION
     ══════════════════════════════════════════════════ */
@@ -2158,6 +2239,13 @@
     <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
   </button>
 
+  <!-- Brightness Slider (visible in light mode) -->
+  <div class="brightness-control" aria-label="Adjust page brightness">
+    <svg class="brightness-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+    <input type="range" class="brightness-slider" min="0" max="100" value="100" aria-label="Page brightness" title="Adjust brightness">
+  </div>
+  <div class="brightness-overlay" aria-hidden="true"></div>
+
   <!-- ═══ HERO ═══ -->
   <section class="hero" aria-label="Introduction">
     <div class="hero-bg" aria-hidden="true">
@@ -2231,7 +2319,7 @@
                 <div class="timeline-logo" aria-hidden="true">B</div>
                 <div>
                   <div class="timeline-company">BitGo</div>
-                  <div class="timeline-role">Staff Engineer</div>
+                  <div class="timeline-role">Engineer 3</div>
                 </div>
               </div>
               <div class="timeline-meta">
@@ -2483,7 +2571,7 @@
 
   <!-- Footer -->
   <footer>
-    <p>&copy; <span id="year"></span> Doddanna B &mdash; Built with <span class="heart">&hearts;</span></p>
+    <p>&copy; <span id="year"></span> Doddanna B</p>
   </footer>
 
   <!-- ═══ GAMIFICATION ELEMENTS ═══ -->
@@ -2656,7 +2744,9 @@
       /* Gamification: theme effects + achievements */
       if (typeof themeStarsEffect === 'function' && typeof themeSunriseEffect === 'function') {
         if (next === 'dark') {
-          /* Dark: switch immediately, stars on dark bg */
+          /* Dark: switch immediately, stars on dark bg, clear brightness overlay */
+          var bo = document.querySelector('.brightness-overlay');
+          if (bo) bo.style.background = 'transparent';
           applyTheme(next, true);
           themeStarsEffect();
           if (typeof unlockAchievement === 'function') unlockAchievement('night-owl');
@@ -2688,6 +2778,36 @@
         applyTheme(e.matches ? 'light' : 'dark', true);
       }
     });
+
+    /* ── Brightness Slider ── */
+    (function() {
+      var slider = document.querySelector('.brightness-slider');
+      var overlay = document.querySelector('.brightness-overlay');
+      if (!slider || !overlay) return;
+
+      var stored = localStorage.getItem('page_brightness');
+      if (stored !== null) {
+        slider.value = stored;
+        applyBrightness(Number(stored));
+      }
+
+      slider.addEventListener('input', function() {
+        var val = Number(this.value);
+        applyBrightness(val);
+        localStorage.setItem('page_brightness', val);
+      });
+
+      function applyBrightness(val) {
+        /* 100 = full brightness (no overlay), 0 = max dim (40% dark overlay) */
+        if (val >= 100) {
+          overlay.style.background = 'transparent';
+          return;
+        }
+        var dimAmount = (100 - val) / 100;
+        var opacity = dimAmount * 0.4;
+        overlay.style.background = 'rgba(0, 0, 0, ' + opacity + ')';
+      }
+    })();
 
     /* ── Year ── */
     document.getElementById('year').textContent = new Date().getFullYear();
@@ -2801,7 +2921,7 @@
       })();
 
       /* Hover state for interactive elements */
-      var interactives = document.querySelectorAll('a, button, .tag, .btn, .theme-toggle');
+      var interactives = document.querySelectorAll('a, button, .tag, .btn, .theme-toggle, .brightness-slider');
       interactives.forEach(function(el) {
         el.addEventListener('mouseenter', function() { cursor.classList.add('hovering'); });
         el.addEventListener('mouseleave', function() { cursor.classList.remove('hovering'); });
@@ -3902,7 +4022,7 @@
         return [
           { type: 'heading', text: 'Career Timeline' },
           { type: 'response', text: '' },
-          { type: 'accent', text: '  2024-Present  BitGo        Staff Engineer' },
+          { type: 'accent', text: '  2024-Present  BitGo        Engineer 3' },
           { type: 'response', text: '                Blockchain & Digital Assets' },
           { type: 'response', text: '' },
           { type: 'accent', text: '  2020-2024     Embibe       Staff Engineer' },

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
   <meta name="twitter:image:alt" content="Doddanna B — Staff Engineer, Platform Architect, Blockchain Infrastructure">
 
   <link rel="canonical" href="https://www.doddanna.com">
-  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link rel="icon" type="image/png" href="https://github.com/Doddanna17.png?size=32">
   <link rel="apple-touch-icon" sizes="180x180" href="https://github.com/Doddanna17.png?size=180">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- **Brightness slider**: Page-level brightness control visible only in light mode. Slider dims the page (0-40% dark overlay) so users can reduce glare. Preference saved in localStorage.
- **BitGo title**: Updated role from "Staff Engineer" to "Engineer 3" in timeline and terminal career command.
- **Footer cleanup**: Removed "Built with ♥" — footer now shows just "© 2026 Doddanna B".

## Test plan
- [ ] Switch to light mode — brightness slider appears below theme toggle
- [ ] Drag slider left — page dims progressively
- [ ] Drag slider right — page returns to full brightness
- [ ] Refresh page — brightness preference persists
- [ ] Switch to dark mode — overlay clears, slider hides
- [ ] Check timeline card — BitGo shows "Engineer 3"
- [ ] Open terminal, type `career` — BitGo shows "Engineer 3"
- [ ] Check footer — clean copyright text only
- [ ] Test on mobile (375px) — slider is responsive